### PR TITLE
Overmap sounds

### DIFF
--- a/StarTrek13/Ships/overmap.dm
+++ b/StarTrek13/Ships/overmap.dm
@@ -3,6 +3,9 @@
 
 //	face_atom(A)//////
 
+/area/ // fuck your idea of shoving everything into one file
+	var/current_overmap = "none" // current map an area is on.
+
 var/global/list/overmap_objects = list()
 
 /area/overmap

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -5,6 +5,18 @@
 
 	var/turf/turf_source = get_turf(source)
 
+	if(turf_source.z == 2)
+		var/area/HA
+		var/list/affected_overmaps = list()
+		for(var/obj/structure/overmap/O in oview(7 + extrarange))
+			affected_overmaps += O
+		for(var/mob/living/carbon/human/H in GLOB.mob_living_list)
+			HA = get_area(H)
+			for(var/obj/structure/overmap/O in affected_overmaps)
+				if(HA.current_overmap == O.name)
+					H.playsound_local(get_turf(H), soundin, (300 / (get_dist(source, O))) * 2 , vary, frequency, falloff, channel, pressure_affected, sound(get_sfx(soundin)))
+					break
+
 	//allocate a channel if necessary now so its the same for everyone
 	channel = channel || open_sound_channel()
 


### PR DESCRIPTION
:cl:
add: Overmap sounds
/:cl:

This way people will be able to hear things like explosions, beams being fired, ships zooming away, enemy thrusters kicking on, enemy space pods being launched, self-destruct beacons going off, enemies flying by, and other fun stuff that happens on overmap.

For future reference: When a sound is played on zlevel 2 (overmap) everyone on local overmap structures will hear.